### PR TITLE
HDF5 output capability

### DIFF
--- a/src/init_stockholm.c
+++ b/src/init_stockholm.c
@@ -51,9 +51,9 @@ void _init_stockholm() {
   }
 
   int i,j,k;
-  
+
   i = j = k = 0;
-  
+
 #ifdef X
   real* vx  = Vx->field_cpu;
   real* vx0 = Vx0->field_cpu;
@@ -72,7 +72,7 @@ void _init_stockholm() {
 #endif
   real* rho  = Density->field_cpu;
   real* rho0 = Density0->field_cpu;
-  
+
 #ifdef Z
   for (k=0; k<Nz+2*NGHZ; k++) {
 #endif
@@ -104,24 +104,28 @@ void _init_stockholm() {
   }
 #endif
 
-  sprintf(outputname,"%s0_2d.dat",Density->name);
-  Write2D(Density0, outputname, OUTPUTDIR, GHOSTINC);
+  if (HDF5) {
+    WriteOutputs2dHdf5();
+  } else {
+    sprintf(outputname,"%s0_2d.dat",Density->name);
+    Write2D(Density0, outputname, OUTPUTDIR, GHOSTINC);
 #ifdef X
-  sprintf(outputname,"%s0_2d.dat",Vx->name);
-  Write2D(Vx0, outputname, OUTPUTDIR, GHOSTINC);
+    sprintf(outputname,"%s0_2d.dat",Vx->name);
+    Write2D(Vx0, outputname, OUTPUTDIR, GHOSTINC);
 #endif
 #ifdef Y
-  sprintf(outputname,"%s0_2d.dat",Vy->name);
-  Write2D(Vy0, outputname, OUTPUTDIR, GHOSTINC);
+    sprintf(outputname,"%s0_2d.dat",Vy->name);
+    Write2D(Vy0, outputname, OUTPUTDIR, GHOSTINC);
 #endif
 #ifdef Z
-  sprintf(outputname,"%s0_2d.dat",Vz->name);
-  Write2D(Vz0, outputname, OUTPUTDIR, GHOSTINC);
+    sprintf(outputname,"%s0_2d.dat",Vz->name);
+    Write2D(Vz0, outputname, OUTPUTDIR, GHOSTINC);
 #endif
 #ifdef ADIABATIC
-  sprintf(outputname,"%s0_2d.dat",Energy->name);
-  Write2D(Energy0, outputname, OUTPUTDIR, GHOSTINC);
+    sprintf(outputname,"%s0_2d.dat",Energy->name);
+    Write2D(Energy0, outputname, OUTPUTDIR, GHOSTINC);
 #endif
+  }
 
 }
 
@@ -130,7 +134,7 @@ void init_stockholm() {
   static boolean init = TRUE;
 
   if (init) MULTIFLUID(_init_stockholm());
-  
+
   init = FALSE;
 
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 /** \file main.c
 
-Main file of the distribution. 
+Main file of the distribution.
 Manages the call to initialization
 functions, then the main loop.
 
@@ -13,7 +13,7 @@ real dt;
 real dtemp = 0.0;
 
 int main(int argc, char *argv[]) {
-  
+
   int   i=0, OutputNumber = 0, d;
   char  sepline[]="===========================";
   sprintf (FirstCommand, "%s", argv[0]);
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
 	NbRestart = atoi(argv[i+1]);
 	if ((NbRestart < 0)) {
 	  masterprint ("Incorrect output number\n");
-	  PrintUsage (argv[0]);	  
+	  PrintUsage (argv[0]);
 	}
       }
       if (strchr (argv[i], 'B')) {
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
 	NbRestart = atoi(argv[i+1]);
 	if ((NbRestart < 0)) {
 	  masterprint ("Incorrect output number\n");
-	  PrintUsage (argv[0]);	  
+	  PrintUsage (argv[0]);
 	}
       }
       if (strchr (argv[i], 'D')) {
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
 	prs_exit (1);
   }
 #endif
-  
+
 
 #ifdef MPICUDA
   EarlyDeviceSelection();
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]) {
     sprintf (VersionString, "FARGO3D git version %s", xstr(VERSION));
   masterprint("\n\n%s\n%s\nSETUP: '%s'\n%s\n\n",
 	      sepline, VersionString, xstr(SETUPNAME), sepline);
-  
+
   if ((ParameterFile[0] == 0) || (argc == 1)) PrintUsage (argv[0]);
 
 #ifndef MPICUDA
@@ -223,14 +223,16 @@ int main(int argc, char *argv[]) {
     prs_exit(EXIT_FAILURE);
   }
 #endif
-    
-  ListVariables ("variables.par"); //Writes all variables defined in set up
-  ListVariablesIDL ("IDL.var");
+
+  if (!HDF5) {
+	ListVariables ("variables.par"); //Writes all variables defined in set up
+	ListVariablesIDL ("IDL.var");
+  }
   ChangeArch(); /*Changes the name of the main functions
 		  ChangeArch adds _cpu or _gpu if GPU is activated.*/
   split(&Gridd); /*Split mesh over PEs*/
   InitSpace();
-  WriteDim();
+  if (!HDF5) WriteDim();
   InitSurfaces();
   LightGlobalDev(); /* Copy light arrays to the device global memory */
   CreateFields(); // Allocate all fields.
@@ -245,14 +247,14 @@ the target velocity in Stockholm's damping prescription. We copy the
 value above *after* rescaling, and after any initial correction to
 OMEGAFRAME (which is used afterwards to build the initial Vx field. */
 
-  
+
   if(Restart == YES || Restart_Full == YES) {
     CondInit (); //Needed even for restarts: some setups have custom
 		 //definitions (eg potential for setup MRI) or custom
 		 //scaling laws (eg. setup planetesimalsRT).
 
     MULTIFLUID( begin_i  = RestartSimulation(NbRestart));
-    
+
     if (ThereArePlanets) {
       PhysicalTime  = GetfromPlanetFile (NbRestart, 9, 0);
       OMEGAFRAME  = GetfromPlanetFile (NbRestart, 10, 0);
@@ -260,7 +262,7 @@ OMEGAFRAME (which is used afterwards to build the initial Vx field. */
     }
   }
   else {
-    if (ThereArePlanets)
+    if (!HDF5 && ThereArePlanets)
       EmptyPlanetSystemFiles ();
     CondInit(); // Initialize set up
     // Note: CondInit () must be called only ONCE (otherwise some
@@ -270,7 +272,7 @@ OMEGAFRAME (which is used afterwards to build the initial Vx field. */
   if (StretchOldOutput == YES) {
     StretchOutput (StretchNumber);
   }
-  
+
   MULTIFLUID(comm(ENERGY)); //Very important for isothermal cases!
 
   /* This must be placed ***after*** reading the input files in case of a restart */
@@ -300,6 +302,28 @@ if (*SPACING=='N'){
   prs_exit (1);
 #endif
 
+  if (HDF5) {
+	if (SetupOutputHdf5() != 0) {
+      mastererr("HDF5 output initialization failed!\n");
+      exit(EXIT_FAILURE);
+	}
+
+	if (WriteDomainHdf5() != 0) {
+      mastererr("HDF5 domain write failed!\n");
+      exit(EXIT_FAILURE);
+	}
+
+	if (WriteParametersHdf5() != 0) {
+      mastererr("HDF5 parameters write failed!\n");
+      exit(EXIT_FAILURE);
+	}
+
+	if (ThereArePlanets && (WritePlanetsHdf5() != 0)) {
+      mastererr("HDF5 planets write failed!\n");
+      exit(EXIT_FAILURE);
+	}
+  }
+
   GetHostsList ();
   DumpToFargo3drc(argc, argv);
 
@@ -307,46 +331,47 @@ if (*SPACING=='N'){
 #ifdef LONGSUMMARY
   ExtractFromExecutable (NO, ArchFile, 2);
 #endif
-  
+
   MULTIFLUID(FillGhosts(PrimitiveVariables()));
 
-  
-#ifdef STOCKHOLM 
+
+#ifdef STOCKHOLM
   FARGO_SAFE(init_stockholm()); //ALREADY IMPLEMENTED MULTIFLUID COMPATIBILITY
 #endif
-  
+
 #ifdef GHOSTSX
   masterprint ("\n\nNew version with ghost zones in X activated\n");
 #else
   masterprint ("Standard version with no ghost zones in X\n");
 #endif
-  
+
   for (i = begin_i; i<=NTOT; i++) { // MAIN LOOP
     if (NINTERM * (TimeStep = (i / NINTERM)) == i) {
 
 #if defined(MHD) && defined(DEBUG)
       FARGO_SAFE(ComputeDivergence(Bx, By, Bz));
 #endif
-      if (ThereArePlanets)
-	WritePlanetSystemFile(TimeStep, NO);
-      
+      if (!HDF5 && ThereArePlanets)
+	    WritePlanetSystemFile(TimeStep, NO);
+
 #ifndef NOOUTPUTS
-      MULTIFLUID(WriteOutputs(ALL));
-      
+	  if (HDF5) WriteOutputsHdf5();
+	  else MULTIFLUID(WriteOutputs(ALL));
+
 #ifdef MATPLOTLIB
       Display();
 #endif
-      
+
       if(CPU_Master) printf("OUTPUTS %d at date t = %f OK\n", TimeStep, PhysicalTime);
 #endif
-      
+
       if (TimeInfo == YES) GiveTimeInfo (TimeStep);
 
     }
-    
+
     if (NSNAP != 0) {
       if (NSNAP * (TimeStep = (i / NSNAP)) == i) {
-	MULTIFLUID(WriteOutputs(SPECIFIC));
+		if (!HDF5) MULTIFLUID(WriteOutputs(SPECIFIC));
 #ifdef MATPLOTLIB
 	Display();
 #endif
@@ -355,11 +380,11 @@ if (*SPACING=='N'){
 
     if (i==NTOT)
       break;
-    
+
     dtemp = 0.0;
-    
+
     while (dtemp<DT) { // DT LOOP
-      
+
       /// AT THIS STAGE Vx IS THE INITIAL TOTAL VELOCITY IN X
 #ifdef X
 #ifndef STANDARD
@@ -367,7 +392,7 @@ if (*SPACING=='N'){
 #endif
 #endif
       /// NOW THE 2D MESH VxMed CONTAINS THE AZIMUTHAL AVERAGE OF Vx in X
-      
+
 #ifdef FLOOR
       MULTIFLUID(Floor());
 #endif
@@ -386,7 +411,7 @@ if (*SPACING=='N'){
 
       // CFL condition is applied below ----------------------------------------
       MULTIFLUID(cfl());
-      
+
       CflFluidsMin(); /*Fills StepTime with the " global min " of the
 			cfl, computed from each fluid.*/
       dt = StepTime; //cfl works with the 'StepTime' global variable.
@@ -394,20 +419,20 @@ if (*SPACING=='N'){
       dtemp+=dt;
       if(dtemp>DT)  dt = DT - (dtemp-dt); //updating dt
       //------------------------------------------------------------------------
-      
+
       //------------------------------------------------------------------------
       /* We now compute the total density of the mesh. We need first
 	 reset an array and then fill it by adding the density of each
 	 fluid */
-      FARGO_SAFE(Reset_field(Total_Density)); 
-      MULTIFLUID(ComputeTotalDensity()); 
+      FARGO_SAFE(Reset_field(Total_Density));
+      MULTIFLUID(ComputeTotalDensity());
       //------------------------------------------------------------------------
 
-      
+
 #ifdef COLLISIONPREDICTOR
       FARGO_SAFE(Collisions(0.5*dt, 0)); // 0 --> V is used and we update v_half.
 #endif
-      
+
       MULTIFLUID(Sources(dt)); //v_half is used in the R.H.S
 
 #ifdef DRAGFORCE
@@ -417,7 +442,7 @@ if (*SPACING=='N'){
 #ifdef DUSTDIFFUSION
       FARGO_SAFE(DustDiffusion_Main(dt));
 #endif
-      
+
       MULTIFLUID(Transport(dt));
 
       PhysicalTime+=dt;
@@ -446,24 +471,31 @@ if (*SPACING=='N'){
       FullArrayComms = 0;
       ContourComms = 0;
     }
-    
+
     if(CPU_Master) printf("%s", "\n");
-    
-    MULTIFLUID(MonitorGlobal (MONITOR2D      |	\
-			      MONITORY       |	\
-			      MONITORY_RAW   |	\
-			      MONITORSCALAR  |	\
-			      MONITORZ       |	\
-			      MONITORZ_RAW));
+
+	if (!HDF5) {
+      MULTIFLUID(MonitorGlobal (MONITOR2D      |	\
+	    		      MONITORY       |	\
+	    		      MONITORY_RAW   |	\
+	    		      MONITORSCALAR  |	\
+	    		      MONITORZ       |	\
+	    		      MONITORZ_RAW));
+	}
 
     if (ThereArePlanets) {
-      WritePlanetSystemFile(TimeStep, YES);
-      SolveOrbits (Sys);
+	  if (HDF5) {
+		WritePlanetsHdf5();
+	  } else {
+        WritePlanetSystemFile(TimeStep, YES);
+        SolveOrbits (Sys);
+	  }
     }
   }
-  
+
+  if (HDF5) TeardownOutputHdf5();
   MPI_Finalize();
-  
+
   masterprint("End of the simulation!\n");
-  return 0;  
+  return 0;
 }

--- a/src/mpi_dummy.c
+++ b/src/mpi_dummy.c
@@ -15,6 +15,8 @@ void MPI_Comm_rank (int a, int *b) {*b = 0;} /* Only one process, with rank zero
 
 void MPI_Comm_size (int a, int *b) {*b = 1;} /* Only one process in the world communicator... */
 
+void MPI_Comm_dup(MPI_Comm a, MPI_Comm *b) { *b = a; }
+
 void MPI_Init (int *argc, char **argv[]) {
   fprintf (stderr, "\n       !!!! WARNING !!!!\n\n");
   fprintf (stderr, "This is a sequential built of the %s code\n", *argv[0]);
@@ -88,4 +90,6 @@ void MPI_Recv(){}
 void MPI_Barrier(){}
 void MPI_Wait(){}
 void MPI_Scan(){} //In place scans require no special action
+void MPI_Exscan(){}
 void MPI_Comm_split(){}
+void MPI_Comm_free(MPI_Comm *){}

--- a/src/mpi_dummy.h
+++ b/src/mpi_dummy.h
@@ -4,6 +4,7 @@
 #define MPI_FLOAT 4
 #define MPI_CHAR 1
 #define MPI_LONG 3
+#define MPI_UNSIGNED_LONG 5
 #define MPI_INT 0
 #define MPI_MIN 0
 #define MPI_MAX 0
@@ -19,7 +20,10 @@ typedef long MPI_Offset;
 void MPI_Comm_rank();
 void MPI_Barrier();
 void MPI_Comm_size();
+void MPI_Comm_dup(MPI_Comm, MPI_Comm*);
+void MPI_Comm_free(MPI_Comm*);
 void MPI_Scan();
+void MPI_Exscan();
 void MPI_Comm_split();
 void MPI_Init();
 void MPI_Finalize();

--- a/src/output_hdf5.c
+++ b/src/output_hdf5.c
@@ -1,0 +1,937 @@
+#include <hdf5.h>
+#include <time.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fargo3d.h"
+
+extern int Id_Var;
+extern Param Var_Set[];
+
+#ifdef FLOAT
+/* single-precision mode */
+#define REALTYPE        (H5T_NATIVE_FLOAT)
+#else
+/* double-precision mode */
+#define REALTYPE        (H5T_NATIVE_DOUBLE)
+#endif
+
+#define FIELDS_PER_PLANET     (8)
+
+static int fields_per_fluid = 2;
+static int static_fields_per_fluid = 1;
+
+static struct {
+  MPI_Comm world_comm;
+
+  hid_t file_id;          /* file handle */
+  hid_t xfpl_id;          /* data transfer prop list */
+
+  struct {
+    hid_t group_id;
+    hid_t memspace_id;
+    hid_t **dataset_ids;  /* planet output dataset handles */
+  } fluids;
+
+#ifdef STOCKHOLM
+  struct {
+    hid_t group_id;       /* stockholm group handle */
+    hid_t **dataset_ids;  /* stockholm dataset handles */
+    hid_t memspace_id;
+  } stockholm;            /* handles for stockholm boundary output */
+#endif
+
+  struct {
+    hid_t dtype_id;       /* custom datatype for planets */
+    hid_t memspace_id;    /* memory dataspace handle */
+    hid_t *dataset_ids;   /* planet output dataset handles */
+  } planets;              /* handles for planet output */
+
+  hsize_t global_file_dims[4];
+  hsize_t global_file_maxdims[4];
+  hsize_t local_mem_dims[4];
+  hsize_t write_dims[4];
+  hsize_t ghost_dims[4];
+  hsize_t chunk_dims[4];
+
+  hsize_t global_file_start[4];
+  hsize_t global_file_ghost_start[4];
+} hdf5;
+
+static int WriteFieldStatic(hid_t dset, void *buffer);
+static int WriteFieldTimeDep(hid_t dset, void *buffer);
+
+static int WriteRealAttribute(const char *name, real val);
+static int WriteIntAttribute(const char *name, int val);
+static int WriteBoolAttribute(const char *name, boolean val);
+static int WriteStringAttribute(const char *name, const char *val);
+
+int SetupOutputHdf5() {
+  size_t len;
+  char *fname;
+  int rank = 0;
+
+  htri_t avail;           /* flag to check for plugins */
+  hid_t fapl_id;          /* file access prop list */
+
+  hid_t fluids_dcpl_id;       /* dataset creation prop list */
+  hid_t fluids_group_id;
+  hid_t fluids_filespace_id;
+  hid_t *fluids_subgroup_ids; /* group handles for fluid fields */
+#ifdef STOCKHOLM
+  hid_t stockholm_dcpl_id;
+  hid_t stockholm_filespace_id;
+  hid_t *stockholm_subgroup_ids; /* group handles for stockholm fields */
+#endif
+
+#ifdef Z
+  fields_per_fluid += 1;
+  static_fields_per_fluid += 1;
+#endif
+#ifdef Y
+  fields_per_fluid += 1;
+  static_fields_per_fluid += 1;
+#endif
+#ifdef X
+  fields_per_fluid += 1;
+  static_fields_per_fluid += 1;
+#endif
+#ifdef ADIABATIC
+  static_fields_per_fluid += 1;
+#endif
+
+  MPI_Comm_dup(MPI_COMM_WORLD, &(hdf5.world_comm));
+
+  /* form the output filename from the directory and a user-supplied tag */
+  len = strlen(OUTPUTDIR) + strlen(FILETAG) + 5;
+  fname = malloc(len * sizeof(char));
+  snprintf(fname, len, "%s/%s.h5", OUTPUTDIR, FILETAG);
+
+  fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+  hdf5.xfpl_id = H5Pcreate(H5P_DATASET_XFER);
+#ifdef PARALLEL
+  /* if we're working in parallel, we need to tell the library; this allows
+   * writing to the same file from multiple processes */
+  H5Pset_fapl_mpio(fapl_id, hdf5.world_comm, MPI_INFO_NULL);
+  H5Pset_dxpl_mpio(hdf5.xfpl_id, H5FD_MPIO_COLLECTIVE);
+#endif
+  H5Pset_libver_bounds(fapl_id, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+
+  /* create the file handle */
+  hdf5.file_id = H5Fcreate(fname, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
+  free(fname);
+  if (hdf5.file_id < 0) return -1;
+
+  /* set up for fluid output */
+  fluids_group_id = H5Gcreate(hdf5.file_id,
+      "fluids", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  if (hdf5.fluids.group_id < 0) return -1;
+
+  /* 0. add a time dimension */
+  hdf5.global_file_dims[rank] = 0;
+  hdf5.global_file_maxdims[rank] = H5S_UNLIMITED;
+  hdf5.chunk_dims[rank] = 1;
+  hdf5.local_mem_dims[rank] = 1;
+  hdf5.write_dims[rank] = 1;
+  hdf5.ghost_dims[rank] = 0;
+  rank += 1;
+
+  /* 1. if enabled, add z dimension */
+#ifdef Z
+  hdf5.global_file_dims[rank] = NZ;
+  hdf5.write_dims[rank] = Nz;
+  hdf5.ghost_dims[rank] = Nz + NGHZ * (Gridd.K == 0) +
+    NGHZ * (Gridd.K + 1 == Gridd.NK);
+#ifdef WRITEGHOSTS
+  hdf5.global_file_dims[rank] += 2 * NGHZ;
+  hdf5.write_dims[rank] += NGHZ * (Gridd.K == 0) +
+    NGHZ * (Gridd.K + 1 == Gridd.NK);
+#endif
+  hdf5.global_file_maxdims[rank] =
+    hdf5.chunk_dims[rank] = hdf5.global_file_dims[rank];
+  hdf5.local_mem_dims[rank] = Nz + 2 * NGHZ;
+  rank += 1;
+#endif  // Z
+
+    /* 2. if enabled, add y dimension */
+#ifdef Y
+  hdf5.global_file_dims[rank] = NY;
+  hdf5.write_dims[rank] = Ny;
+  hdf5.ghost_dims[rank] = Ny + NGHY * (Gridd.J == 0) +
+    NGHY * (Gridd.J + 1 == Gridd.NJ);
+#ifdef WRITEGHOSTS
+  hdf5.global_file_dims[rank] += 2 * NGHY;
+  hdf5.write_dims[rank] += NGHY * (Gridd.J == 0) +
+    NGHY * (Gridd.J + 1 == Gridd.NJ);
+#endif
+  hdf5.global_file_maxdims[rank] =
+    hdf5.chunk_dims[rank] = hdf5.global_file_dims[rank];
+  hdf5.local_mem_dims[rank] = Ny + 2 * NGHY;
+  rank += 1;
+#endif  // Y
+
+  /* 3. if enabled, add x dimension; note that the x dimension isn't
+   * split over multiple ranks */
+#ifdef X
+  hdf5.global_file_dims[rank] = NX;
+  hdf5.write_dims[rank] = Nx;
+  hdf5.ghost_dims[rank] = Nx + 2 * NGHX;
+#ifdef WRITEGHOSTS
+  hdf5.global_file_dims[rank] += 2 * NGHX;
+  hdf5.write_dims[rank] += 2 * NGHX;
+#endif
+  hdf5.global_file_maxdims[rank] =
+    hdf5.chunk_dims[rank] = hdf5.global_file_dims[rank];
+  hdf5.local_mem_dims[rank] = Nx + 2 * NGHX;
+  rank += 1;
+#endif  // X
+
+  /* filespace expands with time, memspace does not */
+  fluids_filespace_id = H5Screate_simple(rank,
+    hdf5.global_file_dims, hdf5.global_file_maxdims);
+  hdf5.fluids.memspace_id = H5Screate_simple(rank, hdf5.local_mem_dims, NULL);
+
+#ifdef STOCKHOLM
+  /* stockholm output isn't time-dependent */
+  stockholm_filespace_id = H5Screate_simple(rank - 2,
+    hdf5.global_file_dims + 1, hdf5.global_file_maxdims + 1);
+  hdf5.stockholm.memspace_id = H5Screate_simple(rank - 2,
+    hdf5.local_mem_dims + 1, NULL);
+#endif
+
+  /* unlimited-dimension datasets **must** be chunked */
+  fluids_dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_chunk(fluids_dcpl_id, rank, hdf5.chunk_dims);
+  avail = H5Zfilter_avail(H5Z_FILTER_DEFLATE);
+  if (avail && (COMPRESSLEVEL > 0)) {
+    /* conditionally enable compression */
+    H5Pset_deflate(fluids_dcpl_id, COMPRESSLEVEL);
+  }
+
+#ifdef STOCKHOLM
+  stockholm_dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_chunk(stockholm_dcpl_id, rank - 2, hdf5.chunk_dims + 1);
+  avail = H5Zfilter_avail(H5Z_FILTER_DEFLATE);
+  if (avail && (COMPRESSLEVEL > 0)) {
+    /* conditionally enable compression */
+    H5Pset_deflate(stockholm_dcpl_id, COMPRESSLEVEL);
+  }
+#endif
+
+  /* allocate memory to store group handles */
+  fluids_subgroup_ids = malloc(NFLUIDS * sizeof(hid_t));
+  if (fluids_subgroup_ids == NULL) return -1;
+#ifdef STOCKHOLM
+  stockholm_subgroup_ids = malloc(NFLUIDS * sizeof(hid_t));
+  if (stockholm_subgroup_ids == NULL) return -1;
+#endif
+
+  /* allocate memory to store dataset handles */
+  hdf5.fluids.dataset_ids = malloc(NFLUIDS * sizeof(hid_t *));
+  if (hdf5.fluids.dataset_ids == NULL) return -1;
+#ifdef STOCKHOLM
+  hdf5.stockholm.dataset_ids = malloc(NFLUIDS * sizeof(hid_t *));
+  if (hdf5.stockholm.dataset_ids == NULL) return -1;
+#endif
+
+  for (int f = 0; f < NFLUIDS; ++f) {
+    int d;        /* local counter for datasets */
+    hid_t gid;    /* local group handle */
+    hid_t subgid; /* local subgroup handle */
+
+    /* create a group for each fluid */
+    gid = H5Gcreate(fluids_group_id, Fluids[f]->name,
+      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (gid < 0) return -1;
+
+    /* allocate memory for dataset handles */
+    hdf5.fluids.dataset_ids[f] = malloc(fields_per_fluid * sizeof(hid_t));
+
+    d = 0; /* create a dataset for each field */
+    hdf5.fluids.dataset_ids[f][d++] = H5Dcreate(gid, "dens", REALTYPE,
+      fluids_filespace_id, H5P_DEFAULT, fluids_dcpl_id, H5P_DEFAULT);
+#ifdef Z
+    hdf5.fluids.dataset_ids[f][d++] = H5Dcreate(gid, "zvel", REALTYPE,
+      fluids_filespace_id, H5P_DEFAULT, fluids_dcpl_id, H5P_DEFAULT);
+#endif
+#ifdef Y
+    hdf5.fluids.dataset_ids[f][d++] = H5Dcreate(gid, "yvel", REALTYPE,
+      fluids_filespace_id, H5P_DEFAULT, fluids_dcpl_id, H5P_DEFAULT);
+#endif
+#ifdef X
+    hdf5.fluids.dataset_ids[f][d++] = H5Dcreate(gid, "xvel", REALTYPE,
+      fluids_filespace_id, H5P_DEFAULT, fluids_dcpl_id, H5P_DEFAULT);
+#endif
+    hdf5.fluids.dataset_ids[f][d++] = H5Dcreate(gid, "ener", REALTYPE,
+      fluids_filespace_id, H5P_DEFAULT, fluids_dcpl_id, H5P_DEFAULT);
+
+#ifdef STOCKHOLM
+    d = 0; /* stockholm group within each fluid */
+    subgid = H5Gcreate(gid, "stockholm", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (subgid < 0) return -1;
+
+    /* allocate memory for dataset handles */
+    hdf5.stockholm.dataset_ids[f] = malloc(static_fields_per_fluid * sizeof(hid_t));
+
+    hdf5.stockholm.dataset_ids[f][d++] = H5Dcreate(subgid, "dens", REALTYPE,
+      stockholm_filespace_id, H5P_DEFAULT, stockholm_dcpl_id, H5P_DEFAULT);
+#ifdef Z
+    hdf5.stockholm.dataset_ids[f][d++] = H5Dcreate(subgid, "zvel", REALTYPE,
+      stockholm_filespace_id, H5P_DEFAULT, stockholm_dcpl_id, H5P_DEFAULT);
+#endif
+#ifdef Y
+    hdf5.stockholm.dataset_ids[f][d++] = H5Dcreate(subgid, "yvel", REALTYPE,
+      stockholm_filespace_id, H5P_DEFAULT, stockholm_dcpl_id, H5P_DEFAULT);
+#endif
+#ifdef X
+    hdf5.stockholm.dataset_ids[f][d++] = H5Dcreate(subgid, "xvel", REALTYPE,
+      stockholm_filespace_id, H5P_DEFAULT, stockholm_dcpl_id, H5P_DEFAULT);
+#endif
+#ifdef ADIABATIC
+    hdf5.stockholm.dataset_ids[f][d++] = H5Dcreate(subgid, "ener", REALTYPE,
+      stockholm_filespace_id, H5P_DEFAULT, stockholm_dcpl_id, H5P_DEFAULT);
+#endif
+
+    H5Gclose(subgid);     /* close temporary handle */
+#endif  // STOCKHOLM
+
+    H5Gclose(gid);        /* close temporary handle */
+  }
+
+    /* can close these handles, datasets are created */
+  H5Pclose(fapl_id);
+  H5Pclose(fluids_dcpl_id);
+  H5Gclose(fluids_group_id);
+  H5Sclose(fluids_filespace_id);
+#ifdef STOCKHOLM
+  H5Pclose(stockholm_dcpl_id);
+  H5Sclose(stockholm_filespace_id);
+#endif
+
+  if (ThereArePlanets && (Sys != NULL)) {
+    size_t sz, count = 0;
+    hid_t planets_filespace_id, group_id, dcpl_id;
+    hsize_t chunkdim = 1, dim = 0, maxdim = H5S_UNLIMITED;
+
+    group_id = H5Gcreate(hdf5.file_id, "planets",
+        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (group_id < 0) return -1;
+
+    dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+    H5Pset_chunk(dcpl_id, 1, &chunkdim);
+    avail = H5Zfilter_avail(H5Z_FILTER_DEFLATE);
+    if (avail && (COMPRESSLEVEL > 0)) {
+        H5Pset_deflate(dcpl_id, COMPRESSLEVEL);
+    }
+
+    /* planet data is essentially a big array of "scalars" (actually
+     * compound structs), so only need rank 1 */
+    planets_filespace_id = H5Screate_simple(1, &dim, &maxdim);
+    hdf5.planets.memspace_id = H5Screate(H5S_SCALAR);
+
+    sz = H5Tget_size(REALTYPE);
+    hdf5.planets.dtype_id = H5Tcreate(H5T_COMPOUND, FIELDS_PER_PLANET * sz);
+
+    H5Tinsert(hdf5.planets.dtype_id, "t",    sz * (count++), REALTYPE);
+    H5Tinsert(hdf5.planets.dtype_id, "mass", sz * (count++), REALTYPE);
+
+    H5Tinsert(hdf5.planets.dtype_id, "x", sz * (count++), REALTYPE);
+    H5Tinsert(hdf5.planets.dtype_id, "y", sz * (count++), REALTYPE);
+    H5Tinsert(hdf5.planets.dtype_id, "z", sz * (count++), REALTYPE);
+
+    H5Tinsert(hdf5.planets.dtype_id, "xvel", sz * (count++), REALTYPE);
+    H5Tinsert(hdf5.planets.dtype_id, "yvel", sz * (count++), REALTYPE);
+    H5Tinsert(hdf5.planets.dtype_id, "zvel", sz * (count++), REALTYPE);
+
+    /* create a dataset per planet in the system */
+    hdf5.planets.dataset_ids = malloc(Sys->nb * sizeof(hid_t));
+    if (hdf5.planets.dataset_ids == NULL) return -1;
+
+    for (int pl = 0; pl < Sys->nb; ++pl) {
+      hdf5.planets.dataset_ids[pl] = H5Dcreate(group_id, Sys->name[pl],
+        hdf5.planets.dtype_id, planets_filespace_id, H5P_DEFAULT,
+        dcpl_id, H5P_DEFAULT);
+    }
+
+    /* close temporary handles */
+    H5Pclose(dcpl_id);
+    H5Gclose(group_id);
+    H5Sclose(planets_filespace_id);
+  }
+
+  {
+    /* a little trick for determining which indices should be written
+     * by each processor, using the grid indices that have already been
+     * assigned and an exclusive sum */
+    int rank = 0;
+    MPI_Comm tmp_comm;
+
+    /* time dimension */
+    hdf5.global_file_start[rank] = 0;
+    hdf5.global_file_ghost_start[rank] = 0;
+    rank += 1;
+
+#ifdef Z
+    MPI_Comm_split(hdf5.world_comm, Gridd.J, CPU_Rank, &tmp_comm);
+    MPI_Exscan(&(hdf5.write_dims[rank]), &(hdf5.global_file_start[rank]),
+      1, MPI_UNSIGNED_LONG, MPI_SUM, tmp_comm);
+    MPI_Exscan(&(hdf5.ghost_dims[rank]), &(hdf5.global_file_ghost_start[rank]),
+      1, MPI_UNSIGNED_LONG, MPI_SUM, tmp_comm);
+    MPI_Comm_free(&tmp_comm);
+    rank += 1;
+#endif
+
+#ifdef Y
+    MPI_Comm_split(hdf5.world_comm, Gridd.K, CPU_Rank, &tmp_comm);
+    MPI_Exscan(&(hdf5.write_dims[rank]), &(hdf5.global_file_start[rank]),
+      1, MPI_UNSIGNED_LONG, MPI_SUM, tmp_comm);
+    MPI_Exscan(&(hdf5.ghost_dims[rank]), &(hdf5.global_file_ghost_start[rank]),
+      1, MPI_UNSIGNED_LONG, MPI_SUM, tmp_comm);
+    MPI_Comm_free(&tmp_comm);
+    rank += 1;
+#endif
+
+#ifdef X
+    hdf5.global_file_start[rank] = 0;
+    hdf5.global_file_ghost_start[rank] = 0;
+    rank += 1;
+#endif
+  }
+
+  return 0;
+}
+
+int WriteDomainHdf5() {
+  hid_t filespace_id, memspace_id;
+  hid_t group_id, dataset_id, dcpl_id;
+  hsize_t memsz, memst, memct, filesz;
+
+  int rank = 1;
+
+  MPI_Barrier(hdf5.world_comm);
+
+  group_id = H5Gcreate(hdf5.file_id,
+    "domain", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  if (group_id < 0) return -1;
+
+#ifdef Z
+  /* memory start index, memory count, memory total size, and file total size
+   * for the z-coordinate data */
+  memst = NGHZ * (Gridd.K > 0);
+  memct = Nz + NGHZ * (Gridd.K == 0) + (NGHZ + 1) * (Gridd.K + 1 == Gridd.NK);
+  memsz = Nz + 2 * NGHZ + 1;
+  filesz = NZ + 2 * NGHZ + 1;
+
+  dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_chunk(dcpl_id, 1, &memsz);
+
+  filespace_id = H5Screate_simple(1, &filesz, NULL);
+  memspace_id = H5Screate_simple(1, &memsz, NULL);
+
+  dataset_id = H5Dcreate(group_id, "z", REALTYPE,
+    filespace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+
+  if (Gridd.J == 0) {
+    /* only one rank should write this data, otherwise it gets re-written
+     * for every processor in y */
+    H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET,
+      &(hdf5.global_file_ghost_start[rank]), NULL, &memct, NULL);
+    H5Sselect_hyperslab(memspace_id, H5S_SELECT_SET,
+      &memst, NULL, &memct, NULL);
+  } else {
+    /* to keep all other processors from writing, since H5Dwrite must be
+     * collective, just clear the hyperslab selection */
+    H5Sselect_none(filespace);
+    H5Sselect_none(memspace);
+  }
+
+  /* do the write operation */
+  H5Dwrite(dataset_id, REALTYPE, memspace_id, filespace_id, hdf5.xfpl_id, Zmin);
+
+  H5Pclose(dcpl_id);
+  H5Dclose(dataset_id);
+  H5Sclose(memspace_id);
+  H5Sclose(filespace_id);
+
+  rank += 1;
+#endif
+#ifdef Y
+  /* memory start index, memory count, memory total size, and file total size
+   * for the y-coordinate data */
+  memst = NGHY * (Gridd.J > 0);
+  memct = Ny + NGHY * (Gridd.J == 0) + (NGHY + 1) * (Gridd.J + 1 == Gridd.NJ);
+  memsz = Ny + 2 * NGHY + 1;
+  filesz = NY + 2 * NGHY + 1;
+
+  dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_chunk(dcpl_id, 1, &memsz);
+
+  filespace_id = H5Screate_simple(1, &filesz, NULL);
+  memspace_id = H5Screate_simple(1, &memsz, NULL);
+
+  dataset_id = H5Dcreate(group_id, "y", REALTYPE,
+    filespace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+
+  if (Gridd.K == 0) {
+    /* only one rank should write this data, otherwise it gets re-written
+     * for every processor in y */
+    H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET,
+      &(hdf5.global_file_ghost_start[rank]), NULL, &memct, NULL);
+    H5Sselect_hyperslab(memspace_id, H5S_SELECT_SET,
+      &memst, NULL, &memct, NULL);
+  } else {
+    /* to keep all other processors from writing, since H5Dwrite must be
+     * collective, just clear the hyperslab selection */
+    H5Sselect_none(filespace_id);
+    H5Sselect_none(memspace_id);
+  }
+
+  /* do the write operation */
+  H5Dwrite(dataset_id, REALTYPE, memspace_id, filespace_id, hdf5.xfpl_id, Ymin);
+
+  H5Pclose(dcpl_id);
+  H5Dclose(dataset_id);
+  H5Sclose(memspace_id);
+  H5Sclose(filespace_id);
+
+  rank += 1;
+#endif
+#ifdef X
+  /* memory start index and memory total size for the x-coordinate data */
+  memst = 0;
+  memsz = Nx + 2 * NGHX + 1;
+
+  dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_chunk(dcpl_id, 1, &memsz);
+
+  filespace_id = H5Screate_simple(1, &memsz, NULL);
+  memspace_id = H5Screate_simple(1, &memsz, NULL);
+
+  dataset_id = H5Dcreate(group_id, "x", REALTYPE,
+    filespace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+
+  if ((Gridd.J == 0) && (Gridd.K == 0)) {
+    /* the x-coordinate isn't split across ranks; limit writing to just
+     * the (0,0) rank, which is always guaranteed to exist, even for
+     * sequential runs */
+    H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET,
+      &memst, NULL, &memsz, NULL);
+    H5Sselect_hyperslab(memspace_id, H5S_SELECT_SET,
+      &memst, NULL, &memsz, NULL);
+  } else {
+    /* to keep all other processors from writing, since H5Dwrite must be
+     * collective, just clear the hyperslab selection */
+    H5Sselect_none(filespace_id);
+    H5Sselect_none(memspace_id);
+  }
+
+  H5Dwrite(dataset_id, REALTYPE, memspace_id, filespace_id, hdf5.xfpl_id, Xmin);
+
+  H5Pclose(dcpl_id);
+  H5Dclose(dataset_id);
+  H5Sclose(memspace_id);
+  H5Sclose(filespace_id);
+
+  rank += 1;
+#endif
+
+  /* close the group, we're done with it */
+  H5Gclose(group_id);
+  /* make sure all ranks are done writing */
+  MPI_Barrier(hdf5.world_comm);
+
+  return 0;
+}
+
+int WriteFieldTimeDep(hid_t dset_id, void *buffer) {
+  /* Write a time-dependent field (maximum rank 4, time + z + y + x)
+   * to the open file in a multiprocess-safe way. */
+  int err, rank = 0;
+  hid_t filespace_id;
+  hsize_t file_dims[4], file_start[4];
+
+  /* get the "old" dataspace global dimensions */
+  filespace_id = H5Dget_space(dset_id);
+  H5Sget_simple_extent_dims(filespace_id, file_dims, NULL);
+  H5Sclose(filespace_id);
+
+  /* increase the first dimension by 1 for this timestep */
+  file_start[rank++] = file_dims[0];
+  file_dims[0] += 1;
+  H5Dset_extent(dset_id, file_dims);
+  filespace_id = H5Dget_space(dset_id);
+
+  /* other start indices are from precomputed arrays */
+#ifdef Z
+  file_start[rank++] = hdf5.global_file_start[rank];
+#endif
+#ifdef Y
+  file_start[rank++] = hdf5.global_file_start[rank];
+#endif
+#ifdef X
+  file_start[rank++] = 0;
+#endif
+
+  /* select this processor's slab and write the data */
+  H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET,
+    file_start, NULL, hdf5.write_dims, NULL);
+  err = H5Dwrite(dset_id, REALTYPE, hdf5.fluids.memspace_id,
+    filespace_id, hdf5.xfpl_id, buffer);
+  H5Sclose(filespace_id);
+
+  return err;
+}
+
+int WriteFieldStatic(hid_t dset_id, void *buffer) {
+  /* Write a time-independent field (maximum rank 2, z + y)
+   * to the open file in a multiprocess-safe way. This is
+   * only used for the Stockholm boundary data. */
+  int err = 0;
+#ifdef STOCKHOLM
+  int rank = 1;
+  hid_t filespace_id;
+  hsize_t file_dims[4], file_start[4];
+
+  /* get the dataspace but don't modify */
+  filespace_id = H5Dget_space(dset_id);
+
+#ifdef Z
+  file_start[rank++] = hdf5.global_file_start[rank];
+#endif
+#ifdef Y
+  file_start[rank++] = hdf5.global_file_start[rank];
+#endif
+
+  /* select this processor's slab and write the data */
+  H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET,
+    file_start + 1, NULL, hdf5.write_dims + 1, NULL);
+  err = H5Dwrite(dset_id, REALTYPE, hdf5.stockholm.memspace_id,
+    filespace_id, hdf5.xfpl_id, buffer);
+  H5Sclose(filespace_id);
+#endif
+  return err;
+}
+
+int WriteOutputsHdf5() {
+  int err, rank = 0;
+  hsize_t mem_start[4];
+
+  mem_start[rank++] = 0;
+#ifdef Z
+#ifdef WRITEGHOSTS
+  mem_start[rank++] = NGHZ * (Gridd.K > 0);
+#else
+  mem_start[rank++] = NGHZ;
+#endif  // WRITEGHOSTS
+#endif  // Z
+#ifdef Y
+#ifdef WRITEGHOSTS
+  mem_start[rank++] = NGHY * (Gridd.J > 0);
+#else
+  mem_start[rank++] = NGHY;
+#endif  // WRITEGHOSTS
+#endif  // Y
+#ifdef X
+#ifdef WRITEGHOSTS
+  mem_start[rank++] = 0;
+#else
+  mem_start[rank++] = NGHX;
+#endif  // WRITEGHOSTS
+#endif  // X
+
+  MPI_Barrier(hdf5.world_comm);
+  H5Sselect_hyperslab(hdf5.fluids.memspace_id, H5S_SELECT_SET,
+    mem_start, NULL, hdf5.write_dims, NULL);
+
+  for (int f = 0; f < NFLUIDS; ++f) {
+    int d = 0;  /* local dataset counter */
+    hid_t *dset_ids = hdf5.fluids.dataset_ids[f];
+
+    err = WriteFieldTimeDep(dset_ids[d++], Fluids[f]->Density->field_cpu);
+    if (err < 0) return err;
+#ifdef Z
+    err = WriteFieldTimeDep(dset_ids[d++], Fluids[f]->Vz->field_cpu);
+    if (err < 0) return err;
+#endif
+#ifdef Y
+    err = WriteFieldTimeDep(dset_ids[d++], Fluids[f]->Vy->field_cpu);
+    if (err < 0) return err;
+#endif
+#ifdef X
+    err = WriteFieldTimeDep(dset_ids[d++], Fluids[f]->Vx->field_cpu);
+    if (err < 0) return err;
+#endif
+    err = WriteFieldTimeDep(dset_ids[d++], Fluids[f]->Energy->field_cpu);
+    if (err < 0) return err;
+  }
+
+  /* wait until all ranks finish, then flush to disk */
+  MPI_Barrier(hdf5.world_comm);
+  H5Fflush(hdf5.file_id, H5F_SCOPE_GLOBAL);
+
+  return 0;
+}
+
+int WriteOutputs2dHdf5() {
+#ifdef STOCKHOLM
+  int err, rank = 1;
+  hsize_t mem_start[4];
+
+  MPI_Barrier(hdf5.world_comm);
+
+#ifdef Z
+#ifdef WRITEGHOSTS
+  mem_start[rank++] = NGHZ * (Gridd.K == 0);
+#else
+  mem_start[rank++] = NGHZ;
+#endif  // WRITEGHOSTS
+#endif  // Z
+#ifdef Y
+#ifdef WRITEGHOSTS
+  mem_start[rank++] = NGHY * (Gridd.J == 0);
+#else
+  mem_start[rank++] = NGHY;
+#endif  // WRITEGHOSTS
+#endif  // Y
+
+  H5Sselect_hyperslab(hdf5.stockholm.memspace_id, H5S_SELECT_SET,
+    mem_start + 1, NULL, hdf5.write_dims + 1, NULL);
+
+  for (int f = 0; f < NFLUIDS; ++f) {
+    int d = 0;  /* local dataset counter */
+    hid_t *dset_ids = hdf5.stockholm.dataset_ids[f];
+
+    err = WriteFieldStatic(dset_ids[d++], Fluids[f]->Density0->field_cpu);
+    if (err < 0) return err;
+#ifdef Z
+    err = WriteFieldStatic(dset_ids[d++], Fluids[f]->Vz0->field_cpu);
+    if (err < 0) return err;
+#endif
+#ifdef Y
+    err = WriteFieldStatic(dset_ids[d++], Fluids[f]->Vy0->field_cpu);
+    if (err < 0) return err;
+#endif
+#ifdef X
+    err = WriteFieldStatic(dset_ids[d++], Fluids[f]->Vx0->field_cpu);
+    if (err < 0) return err;
+#endif
+#ifdef ADIABATIC
+    err = WriteFieldStatic(dset_ids[d++], Fluids[f]->Energy0->field_cpu);
+    if (err < 0) return err;
+#endif
+  }
+
+  /* wait until all ranks finish, then flush to disk */
+  MPI_Barrier(hdf5.world_comm);
+  H5Fflush(hdf5.file_id, H5F_SCOPE_GLOBAL);
+#endif
+
+  return 0;
+}
+
+int WritePlanetsHdf5() {
+  int err;
+  hid_t filespace_id;
+  hsize_t file_dims, file_start, file_count = 1;
+  real planet_buffer[FIELDS_PER_PLANET];
+
+  for (int pl = 0; pl < Sys->nb; ++pl) {
+    int i = 0;  /* local field counter */
+    hid_t dset_id = hdf5.planets.dataset_ids[pl];
+
+    /* get the "old" dataspace global dimensions */
+    filespace_id = H5Dget_space(dset_id);
+    H5Sget_simple_extent_dims(filespace_id, &file_dims, NULL);
+    H5Sclose(filespace_id);
+
+    /* increase the first (and only) dimension by 1 for this timestep */
+    file_start = file_dims;
+    file_dims += 1;
+    H5Dset_extent(dset_id, &file_dims);
+    filespace_id = H5Dget_space(dset_id);
+
+    planet_buffer[i++] = PhysicalTime;
+    planet_buffer[i++] = Sys->mass[pl];
+
+    planet_buffer[i++] = Sys->x[pl];
+    planet_buffer[i++] = Sys->y[pl];
+    planet_buffer[i++] = Sys->z[pl];
+
+    planet_buffer[i++] = Sys->vx[pl];
+    planet_buffer[i++] = Sys->vy[pl];
+    planet_buffer[i++] = Sys->vz[pl];
+
+    if (CPU_Master) {
+      /* only one rank should write the data */
+      H5Sselect_hyperslab(filespace_id, H5S_SELECT_SET,
+        &file_start, NULL, &file_count, NULL);
+    } else {
+      /* others call H5Dwrite with no elements selected */
+      H5Sselect_none(filespace_id);
+      H5Sselect_none(hdf5.planets.memspace_id);
+    }
+
+    /* write the data */
+    err = H5Dwrite(dset_id, hdf5.planets.dtype_id, hdf5.planets.memspace_id,
+      filespace_id, hdf5.xfpl_id, planet_buffer);
+    if (err < 0) return err;
+
+    H5Sclose(filespace_id);
+  }
+
+  return 0;
+}
+
+int WriteRealAttribute(const char *name, real val) {
+  herr_t err;
+  hid_t att_id, space_id;
+
+  space_id = H5Screate(H5S_SCALAR);
+  if (space_id < 0) return -1;
+
+  att_id = H5Acreate(hdf5.file_id, name,
+    REALTYPE, space_id, H5P_DEFAULT, H5P_DEFAULT);
+  if (att_id < 0) return -1;
+
+  err = H5Awrite(att_id, REALTYPE, &val);
+  if (err < 0) return -1;
+
+  H5Aclose(att_id);
+  H5Sclose(space_id);
+
+  return 0;
+}
+
+int WriteIntAttribute(const char *name, int val) {
+  herr_t err;
+  hid_t att_id, space_id;
+
+  space_id = H5Screate(H5S_SCALAR);
+  if (space_id < 0) return -1;
+
+  att_id = H5Acreate(hdf5.file_id, name,
+    H5T_STD_I32BE, space_id, H5P_DEFAULT, H5P_DEFAULT);
+  if (att_id < 0) return -1;
+
+  err = H5Awrite(att_id, H5T_NATIVE_INT, &val);
+  if (err < 0) return -1;
+
+  H5Aclose(att_id);
+  H5Sclose(space_id);
+
+  return 0;
+}
+
+int WriteBoolAttribute(const char *name, boolean val) {
+  herr_t err;
+  hid_t att_id, space_id;
+
+  space_id = H5Screate(H5S_SCALAR);
+  if (space_id < 0) return -1;
+
+  att_id = H5Acreate(hdf5.file_id, name,
+    H5T_STD_B8BE, space_id, H5P_DEFAULT, H5P_DEFAULT);
+  if (att_id < 0) return -1;
+
+  err = H5Awrite(att_id, H5T_NATIVE_B8, &val);
+  if (err < 0) return -1;
+
+  H5Aclose(att_id);
+  H5Sclose(space_id);
+
+  return 0;
+}
+
+int WriteStringAttribute(const char *name, const char *val) {
+  herr_t err;
+  hid_t att_id, space_id, type_id;
+  size_t len;
+
+  space_id = H5Screate(H5S_SCALAR);
+  if (space_id < 0) return -1;
+
+  type_id = H5Tcopy(H5T_C_S1);
+  if (type_id < 0) return -1;
+
+  len = strlen(val);
+  err = H5Tset_size(type_id, len);
+  if (err < 0) return -1;
+
+  att_id = H5Acreate(hdf5.file_id, name,
+    type_id, space_id, H5P_DEFAULT, H5P_DEFAULT);
+  if (att_id < 0) return -1;
+
+  err = H5Awrite(att_id, type_id, val);
+  if (err < 0) return -1;
+
+  H5Aclose(att_id);
+  H5Tclose(type_id);
+  H5Sclose(space_id);
+
+  return 0;
+}
+
+int WriteParametersHdf5() {
+  for (int i = 0; i < Id_Var; i++) {
+    char *var = Var_Set[i].variable;
+    const char *name = Var_Set[i].name;
+
+    switch (Var_Set[i].type) {
+      case REAL:
+        WriteRealAttribute(name, *((real *) var));
+        break;
+
+      case INT:
+        WriteIntAttribute(name, *((int *) var));
+        break;
+
+      case BOOL:
+        WriteBoolAttribute(name, *((boolean *) var));
+        break;
+
+      case STRING:
+        WriteStringAttribute(name, var);
+        break;
+    }
+  }
+
+  return 0;
+}
+
+void TeardownOutputHdf5() {
+  H5Pclose(hdf5.xfpl_id);
+  H5Sclose(hdf5.fluids.memspace_id);
+#ifdef STOCKHOLM
+  H5Sclose(hdf5.stockholm.memspace_id);
+#endif
+
+  for (int f = 0; f < NFLUIDS; ++f) {
+    for (int i = 0; i < fields_per_fluid; ++i) {
+      H5Dclose(hdf5.fluids.dataset_ids[f][i]);
+    }
+
+    free(hdf5.fluids.dataset_ids[f]);
+
+#ifdef STOCKHOLM
+    for (int i = 0; i < static_fields_per_fluid; ++i) {
+      H5Dclose(hdf5.stockholm.dataset_ids[f][i]);
+    }
+
+    free(hdf5.stockholm.dataset_ids[f]);
+#endif
+  }
+
+  if (ThereArePlanets && (Sys != NULL)) {
+    H5Tclose(hdf5.planets.dtype_id);
+    H5Sclose(hdf5.planets.memspace_id);
+
+    for (int pl = 0; pl < Sys->nb; ++pl) {
+      H5Dclose(hdf5.planets.dataset_ids[pl]);
+    }
+
+    free(hdf5.planets.dataset_ids);
+  }
+
+  H5Fclose(hdf5.file_id);
+  MPI_Comm_free(&(hdf5.world_comm));
+}

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -1,5 +1,5 @@
 #ifdef __GPU
-#define ex extern "C" 
+#define ex extern "C"
 #else
 #define ex extern
 #endif
@@ -253,9 +253,9 @@ ex void SubStep3_cpu(real);
 
 //transport Prototypes
 ex void VanLeerX(Field*, Field*, Field*, real);
-ex void TransportX(Field*, Field*, Field*, real); 
-ex void TransportY(Field*, Field*, real); 
-ex void TransportZ(Field*, Field*, real); 
+ex void TransportX(Field*, Field*, Field*, real);
+ex void TransportY(Field*, Field*, real);
+ex void TransportZ(Field*, Field*, real);
 ex void X_advection (Field*, real);
 ex void transport(real);
 
@@ -313,6 +313,14 @@ ex void WriteVTKMerging(Field *, int);
 ex void write_vtk_header(FILE*, Field*, int);
 ex void write_vtk_coordinates(FILE*, Field*);
 ex void write_vtk_scalar(FILE*, Field*);
+
+ex int SetupOutputHdf5();
+ex int WriteDomainHdf5();
+ex int WriteOutputsHdf5();
+ex int WriteOutputs2dHdf5();
+ex int WritePlanetsHdf5();
+ex int WriteParametersHdf5();
+ex void TeardownOutputHdf5();
 
 //update.c
 ex void UpdateX_cpu(real, Field*, Field*, Field*);
@@ -376,7 +384,7 @@ ex void _LorentzForce_cpu(real, int, int, int, int, int, int, int, int, int, int
 ex void UpdateMagneticField (real, int, int, int);
 ex void _UpdateMagneticField_cpu(real,int,int,int,int,int,int,int,int,int,
 			      Field*,Field*,Field*);
-  
+
 
 ex void ComputeMHD (real);
 ex void ComputeDivergence (Field *, Field *, Field *);

--- a/std/stdpar.par
+++ b/std/stdpar.par
@@ -90,3 +90,6 @@ WriteVz                    No
 WriteDivergence            No
 WriteEnergyRad             No
 WriteTau                   No
+FileTag                    undefined
+CompressLevel              3
+Hdf5                       no


### PR DESCRIPTION
[HDF5](https://www.hdfgroup.org/solutions/hdf5/) is a high-performance I/O library for scientific data. This output module produces exactly one file per run of FARGO3D, with optional compression, in an easy-to-use structured format. It includes all the time-varying fluid fields for all fluids (in the multifluid version), metadata for every array (shape and data type), and all the parameter values used in the run, attached at the root node as attributes. Combined with the Python bindings for HDF5, this has made analyzing output from my runs significantly easier. I hope it can be of use to someone else, and I'm happy to continue developing on this feature branch if the developers are interested in the new functionality.