### PR TITLE
non initialized viscosity coefficient for cylindrical runs (see #21)

### DIFF
--- a/src/visctensor_cyl.c
+++ b/src/visctensor_cyl.c
@@ -150,7 +150,7 @@ void visctensor_cyl_cpu(){
 	viscosityzm   = ALPHA*GAMMA*(GAMMA-1.0)*(energy[l]+energy[lzm]+energy[lxm]+energy[lxm-stride])/(rho[l]+rho[lzm]+rho[lxm]+rho[lxm-stride])*sqrt(ymed(j)*ymed(j)*ymed(j)/(G*MSTAR));
 #endif
 #else
-	viscosityzmym = viscositym = viscosity = NU;
+	viscosityzmym = viscosityzm = viscositym = viscosity = NU;
 #endif
 //Evaluate centered divergence.
 	div_v = 0.0;


### PR DESCRIPTION
In cylindrical runs with constant viscosity, the viscosity coefficient is expected to be initialized with the specified constant value. However, the current code does not initialize it, leading to unexpected results. This issue is reported in #21, and this commit fixes it.